### PR TITLE
Fix admin checks for protected routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import SuperAdmin from "./pages/SuperAdmin";
 import Auth from "./pages/Auth";
 import AuthCallback from "./pages/auth/AuthCallback";
 import ResetPassword from "./pages/auth/ResetPassword";
+import AccessDenied from "./pages/AccessDenied";
 
 const queryClient = new QueryClient();
 
@@ -29,6 +30,7 @@ const App = () => (
                 <Route key={to} path={to} element={page} />
               ))}
               <Route path="/super-admin/*" element={<SuperAdmin />} />
+              <Route path="/access-denied" element={<AccessDenied />} />
             </Routes>
           </BrowserRouter>
         </div>

--- a/src/components/auth/ProtectedRoute.tsx
+++ b/src/components/auth/ProtectedRoute.tsx
@@ -10,11 +10,11 @@ interface ProtectedRouteProps {
   requireAdmin?: boolean;
 }
 
-export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ 
-  children, 
-  requireAdmin = false 
+export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
+  children,
+  requireAdmin = false
 }) => {
-  const { user, isLoading } = useAuth();
+  const { user, isLoading, isAdmin } = useAuth();
 
   if (isLoading) {
     return (
@@ -35,6 +35,9 @@ export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
     return <Navigate to="/auth" replace />;
   }
 
-  // All authenticated users are now automatically admins, so no access denied
+  if (requireAdmin && !isAdmin) {
+    return <Navigate to="/access-denied" replace />;
+  }
+
   return <>{children}</>;
 };

--- a/src/pages/AccessDenied.tsx
+++ b/src/pages/AccessDenied.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+const AccessDenied = () => {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-primary/5 to-secondary/5">
+      <div className="text-center space-y-4">
+        <h1 className="text-4xl font-bold">Access Denied</h1>
+        <p className="text-muted-foreground">You do not have permission to access this page.</p>
+        <a href="/" className="underline text-primary">Return Home</a>
+      </div>
+    </div>
+  );
+};
+
+export default AccessDenied;


### PR DESCRIPTION
## Summary
- add an `AccessDenied` page
- enforce admin authorization in `ProtectedRoute`
- wire up new page in router

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6881da672b188323bbb16226281fb56f